### PR TITLE
Fix auth header for OpenAI transcription

### DIFF
--- a/speechcraft/speechcraft/Source/AppDelegate.swift
+++ b/speechcraft/speechcraft/Source/AppDelegate.swift
@@ -391,7 +391,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.setValue(apiKey, forHTTPHeaderField: serviceType == .openAI ? "Authorization" : "api-key")
+        if serviceType == .openAI {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        } else {
+            request.setValue(apiKey, forHTTPHeaderField: "api-key")
+        }
         let boundary = "Boundary-\(UUID().uuidString)"
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         var body = Data()


### PR DESCRIPTION
## Summary
- update `transcribe(fileURL:)` to prefix `Bearer` token when using OpenAI

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686158544acc8324be9ccfd6768fb548